### PR TITLE
Improve logging for different verbose levels, colors

### DIFF
--- a/bin/http-later.js
+++ b/bin/http-later.js
@@ -11,6 +11,9 @@ var squabble = require("squabble").createParser(),
 // ensure color support enabled
 require("colors");
 
+// add timestamps in front of log messages
+require("console-stamp")(console, "HH:mm:ss.l");
+
 // patch console object
 console.error = noop(console.error).enable();
 console.log = noop(console.log).disable();

--- a/bin/http-later.js
+++ b/bin/http-later.js
@@ -68,16 +68,21 @@ server.on("accepting", function(rule) {
 });
 
 // log some other server events
-server.on("replaying", function() {console.log("replaying".gray);});
-server.on("drain", function() {console.log("drained".gray);});
-server.on("refill", function() {console.log("refilling from queue".gray);});
-server.on("backoff", function(ms) {console.log(("backing off "+ms).gray);});
+if (args.named["--verbose"] > 2) {
+    server.on("replaying", function() {console.log("replaying".gray);});
+    server.on("drain", function()     {console.log("drained".gray);});
+    server.on("refill", function()    {console.log("refilling from queue".gray);});
+    server.on("backoff", function(ms) {console.log(("backing off "+ms).gray);});
+}
+server.on("error", function() {console.log("redis gone.".red);});
 
 // log incoming requests and their initial response
 server.on("request", function(req, res) {
     var status = res.statusCode;
 
     if (status < 200) status = String(status).yellow;
+    else if (status = 200) status = String(status).green;
+    else if (status = 202) status = String(status).green;
     else if (status < 300) status = String(status).cyan;
     else if (status < 500) status = String(status).yellow;
     else status = String(status).red;
@@ -86,24 +91,27 @@ server.on("request", function(req, res) {
 });
 
 // log requests pulled from queue
-server.on("pull", function(req) {
-    console.info(("pull " + requtil.formatLog(req)).gray);
-});
+if (args.named["--verbose"] > 1) {
+    server.on("pull", function(req) {
+        console.log(("pull " + requtil.formatLog(req)).gray);
+    });
 
-// log delayed requests
-server.on("wait", function(req) {
-    console.info(("wait " + requtil.formatLog(req)).gray);
-});
+    // log delayed requests
+    server.on("wait", function(req) {
+        console.log(("wait " + requtil.formatLog(req)).gray);
+    });
 
-// log request replays
-server.on("replay", function(req) {
-    console.info(("play " + requtil.formatLog(req)).gray);
-});
+    // log request replays
+    server.on("replay", function(req) {
+        console.log(("play " + requtil.formatLog(req)).gray);
+    });
+}
 
 // log responses to replayed requests
 server.on("response", function(res, req) {
     var status;
-    status = String(res.statusCode).magenta;
+    if (res.statusCode = 200) status = String(res.statusCode).green
+    else status = String(res.statusCode).magenta;
     console.log(status + " " + requtil.formatLog(req));
 });
 
@@ -155,12 +163,11 @@ function readOpts(opts) {
 
             if (parts.length < 2 || !parts[0] || parts[0] in result) {
                 msg = String("invalid or unrecognized option '" + opt + "'").red;
-                console.log(msg);
+                console.error(msg);
             } else {
                 result[parts[0]] = parts.slice(1).join(":");
             }
         });
-    
+
     return result;
 }
-

--- a/bin/http-later.js
+++ b/bin/http-later.js
@@ -81,10 +81,10 @@ server.on("request", function(req, res) {
     var status = res.statusCode;
 
     if (status < 200) status = String(status).yellow;
-    else if (status = 200) status = String(status).green;
-    else if (status = 202) status = String(status).green;
-    else if (status < 300) status = String(status).cyan;
-    else if (status < 500) status = String(status).yellow;
+    else if (status == 200) status = String(status).green;
+    else if (status == 202) status = String(status).green;
+    else if (status <  300) status = String(status).cyan;
+    else if (status <  500) status = String(status).yellow;
     else status = String(status).red;
 
     console.log(status + " " + requtil.formatLog(req));

--- a/bin/http-later.js
+++ b/bin/http-later.js
@@ -110,7 +110,7 @@ if (args.named["--verbose"] > 1) {
 // log responses to replayed requests
 server.on("response", function(res, req) {
     var status;
-    if (res.statusCode = 200) status = String(res.statusCode).green
+    if (res.statusCode == 200) status = String(res.statusCode).green
     else status = String(res.statusCode).magenta;
     console.log(status + " " + requtil.formatLog(req));
 });

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "squabble": "^1",
     "propertize": "^2",
     "colors": "^1",
+    "console-stamp": "^0.2",
     "async": "^1",
     "concussion": "^1",
     "http-later-redis": "^1",


### PR DESCRIPTION
	https://nodejs.org/api/console.html
		console.info = console.log
		console.warn = console.error

Would be nice to have optional timestamps in front of logging but there
is no simple flag for it and it should be optional if logged by services
which also adds timestams as syslogd for instance.